### PR TITLE
FIO-5953: move to HashRouter from BrowserRouter 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -3,14 +3,14 @@ import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
 import reportWebVitals from "./reportWebVitals";
-import { BrowserRouter } from "react-router-dom";
+import { HashRouter } from "react-router-dom";
 
 const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-    <BrowserRouter basename="/react-app-starterkit">
+    <HashRouter basename="/react-app-starterkit">
       <App />
-    </BrowserRouter>
+    </HashRouter>
   </React.StrictMode>
 );
 


### PR DESCRIPTION
BrowserRouter and Github pages conflict; we'll use a HashRouter to keep routing in sync with the location's hash